### PR TITLE
Fix links in top level README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ This rep is a growing list of Python cheat sheets, tailored for Data Science.
 ***Found any typos or have a suggestion? Fork, contribute and tune it to your taste!***
 
 ### Currently includes:
-* [NumPy](https://github.com/juliangaal/python-cheat-sheet/blob/master/NumPy/NumPy.md)
-* [Matplotlib](https://github.com/juliangaal/python-cheat-sheet/blob/master/Matplotlib/Matplotlib.md)
+* [NumPy](NumPy/README.md)
+* [Matplotlib](Matplotlib/README.md)
 
 ### Installation
 If you want to install a package individually, go into the corresponding `<package-name>.md` file for instructions on how to install.


### PR DESCRIPTION
The links pointed to NumPy.md and Matplotlib.md which were renamed to README.md in cf7a8f2cc5d62995be80895395d74868b8b0c619